### PR TITLE
Fix error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,7 @@
 cd "$GITHUB_WORKSPACE"
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
+export MIX_HOME=/var/mix
 
 mix credo suggest --strict --format=flycheck \
     | reviewdog -efm="%f:%l:%c: %t: %m" -efm="%f:%l: %t: %m" -name="credo" -reporter="${INPUT_REPORTER:-'github-pr-check'}" -level="${INPUT_LEVEL}"


### PR DESCRIPTION
I'm getting an error running this GitHub Action. This change fixes it.

It sets `MIX_HOME` in the entrypoint to the same location that is used in the Dockerfile.

The error is:
`** (Mix) Could not find an SCM for dependency :credo from MyApp.MixProject`