### PR TITLE
Fix git error introduced in git 2.35.2

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 
 cd "$GITHUB_WORKSPACE"
 
+git config --global --add safe.directory $GITHUB_WORKSPACE || exit 1
+
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 mix credo suggest --strict --format=flycheck \


### PR DESCRIPTION
Github Actions starts to fail due to git v2.35.2 spec changes and causes below errors.

```
reviewdog: PullRequest needs 'git' command: failed to run 'git rev-parse --show-prefix': exit status 128
```

Ref. https://github.com/reviewdog/reviewdog/issues/1158 for more info.