### PR TITLE
Fix: Execution Failure

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -9,8 +9,8 @@ jobs:
         uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 24.0
-          elixir-version: 1.12
+          otp-version: 26.2.5
+          elixir-version: 1.16-otp-26
       - name: Install Dependencies
         run: |
           mix local.rebar --force

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.12-alpine
+FROM elixir:1.16-alpine
 
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ v0.17.4
 RUN apk --update add git && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM elixir:1.12-alpine
 
-RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ v0.13.0
+RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ v0.17.4
 RUN apk --update add git && \
     rm -rf /var/lib/apt/lists/* && \
     rm /var/cache/apk/*

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jobs:
     name: runner / credo
     runs-on: ubuntu-latest
     container:
-      image: elixir:1.12-slim
+      image: elixir:1.16-slim
     steps:
       - uses: actions/checkout@v2
       - name: Install Dependencies

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 
 cd "$GITHUB_WORKSPACE"
 
+git config --global --add safe.directory $GITHUB_WORKSPACE || exit 1
+
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 mix credo suggest --strict --format=flycheck \


### PR DESCRIPTION
- Fix git v2.35.2 problem
  - https://github.com/red-shirts/reviewdog-action-credo/pull/10
- Update Elixir version to 1.16. This was necessary due to https://github.com/rrrene/credo/commit/b41545aa780e1f4c1fc46463ed99f81c3a573a3b
- Update reviewdog version to the latest
